### PR TITLE
Proper following of user

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,9 +41,12 @@ def UpdateQueue():
 def CheckForFollowRequest(item):
     text = item['text']
     if "follow" in text.lower():
-        user = item['user']
-        screen_name = user['screen_name']
-        api.request('friendships/create', {'screen_name': screen_name})
+    	try:
+    	    api.request('friendships/create', {'screen_name': item['retweeted_status']['user']['screen_name']
+    	except:
+	    user = item['user']
+            screen_name = user['screen_name']
+            api.request('friendships/create', {'screen_name': screen_name})
 
 
 # Scan for new contests, but not too often because of the rate limit.


### PR DESCRIPTION
the JSON returned by the search may include retweets by tweeters other than the original tweeter. Retweeting these users is fine, since twitter automatically returns the original tweet, however the function to follow a user  originally would follow the retweeter, making the program user ineligible for the giveaway. The fixed code tries to get an entry from retweeted_status that only shows up in retweeted tweets, and contains information about the original tweeter. If this fails (the tweet is not a retweet), it continues as normal.
